### PR TITLE
Add expandable and format text

### DIFF
--- a/main.py
+++ b/main.py
@@ -67,21 +67,25 @@ def filter(cities, customer_types, genders):
     return data_filtered, sales_by_product_line, sales_by_hour
 
 
+def to_text(value):
+    return '{:,}'.format(int(value))
+
+
 with tgb.Page() as page:
     tgb.toggle(theme=True)
     tgb.text("📊 Sales Dashboard", class_name="h1 text-center pb2")
 
     with tgb.layout("1 1 1", class_name="p1"):
         with tgb.part(class_name="card"):
-            tgb.text("Total Sales:", class_name="h2")
-            tgb.text("US $ {int(data_filtered['Total'].sum())}", class_name="h4")
+            tgb.text("## Total Sales:", mode="md")
+            tgb.text("US $ {to_text(data_filtered['Total'].sum())}", class_name="h4")
 
         with tgb.part(class_name="card"):
-            tgb.text("Average Sales:", class_name="h2")
-            tgb.text("{int(data_filtered['Total'].mean())}", class_name="h4")
+            tgb.text("## Average Sales:", mode="md")
+            tgb.text("{to_text(data_filtered['Total'].mean())}", class_name="h4")
 
         with tgb.part(class_name="card"):
-            tgb.text("Average Rating:", class_name="h2")
+            tgb.text("## Average Rating:", mode="md")
             tgb.text(
                 "{round(data_filtered['Rating'].mean(), 1)}"
                 + "{'⭐' * int(round(round(data_filtered['Rating'].mean(), 1), 0))}",
@@ -135,6 +139,9 @@ with tgb.Page() as page:
             layout=layout,
             title="Sales by Product Line",
         )
+
+    with tgb.expandable(title="Filtered Data", expanded=False):
+        tgb.table("{data_filtered}")
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 taipy
-pandas


### PR DESCRIPTION
- I have formatted your text as you wanted by creating a function called *to_text*. You could have used the *format* property of the *text* visual element. However, it doesn't seem to cover the separation of thousands:

![image](https://github.com/Sven-Bo/taipy-sales-dashboard/assets/98709993/d3e5c879-6b9c-42ff-b547-5fb0d4951506)
 
[Doc](https://docs.taipy.io/en/latest/manuals/gui/viselements/text/#formatted-output)

In the next release, we will simplify the creation of text/value like this by having a [*metric* visual element](https://github.com/Avaiga/taipy/issues/551).

- I have added an expandable to your page, which is closed by default.

Your code is clean and straightforward. It will make a great Taipy tutorial.

On a side note, Taipy also supports Plotly natively. You could have also created your Plotly figure and put it inside your chart. However, the way you did it is the best here.

It also displays the best Taipy practices for this dashboard. If you go further into Taipy, there are also features for data management, pipeline execution and management, and multi-page creation, but they are not needed here.
